### PR TITLE
lib/reversi_methods.rbファイルの修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
@@ -63,6 +63,7 @@ module ReversiMethods
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
     return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)
@@ -86,6 +87,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
テストが正しく実行されるように修正しました。

　1. put_stoneメソッド内で、二次元配列のrowとcolの順番が逆になっていたのを修正しました。
　2. 配置しようとしている石のマスの八方向に空白（BLANK_CELL）があった場合、turnメソッド内でfalseを発生させるよう　　　　
　　に修正しました。
　3. placeable?メソッドにfalseを追加して、finished?メソッドが実行されるように修正しました。